### PR TITLE
Rename to m6web/restconnection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "oziks/restconnection",
+    "name": "m6web/restconnection",
     "type": "library",
     "description": "PHP class used to make requests to REST APIs easily.",
     "autoload": {
@@ -7,5 +7,8 @@
             "RESTConnection": "src"
         }
     },
-    "minimum-stability": "dev"
+    "minimum-stability": "dev",
+    "replace": {
+        "oziks/restconnection": "self.version"
+    }
 }


### PR DESCRIPTION
Having to use a custom repository on composer makes things much harder than they need to be, let's take ownership of this package.

I intend to **replace** the current 1.0.0 tag when this is merged.